### PR TITLE
feat: Implement initial Gradle setup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,47 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.anysoftkeyboard.janus.app"
+    compileSdk = 36
+
+    defaultConfig {
+        applicationId = "com.anysoftkeyboard.janus"
+        minSdk = 21
+        targetSdk = 36
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+dependencies {
+    implementation(project(":database"))
+    implementation(project(":network"))
+    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("com.google.android.material:material:1.8.0")
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+}

--- a/app/src/main/java/com/anysoftkeyboard/janus/app/App.kt
+++ b/app/src/main/java/com/anysoftkeyboard/janus/app/App.kt
@@ -1,0 +1,10 @@
+package com.anysoftkeyboard.janus.app
+
+import com.anysoftkeyboard.janus.database.Database
+import com.anysoftkeyboard.janus.network.Network
+
+class App(
+    private val database: Database,
+    private val network: Network,
+) {
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,6 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+plugins {
+    id("com.android.application") version "8.1.0" apply false
+    id("com.android.library") version "8.1.0" apply false
+    id("org.jetbrains.kotlin.android") version "1.8.0" apply false
+}

--- a/database/build.gradle.kts
+++ b/database/build.gradle.kts
@@ -1,0 +1,43 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.anysoftkeyboard.janus.database"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 21
+        targetSdk = 36
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("com.google.android.material:material:1.8.0")
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+}

--- a/database/src/main/java/com/anysoftkeyboard/janus/database/Database.kt
+++ b/database/src/main/java/com/anysoftkeyboard/janus/database/Database.kt
@@ -1,0 +1,4 @@
+package com.anysoftkeyboard.janus.database
+
+interface Database {
+}

--- a/network/build.gradle.kts
+++ b/network/build.gradle.kts
@@ -1,0 +1,43 @@
+plugins {
+    id("com.android.library")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.anysoftkeyboard.janus.network"
+    compileSdk = 36
+
+    defaultConfig {
+        minSdk = 21
+        targetSdk = 36
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.9.0")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("com.google.android.material:material:1.8.0")
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+}

--- a/network/src/main/java/com/anysoftkeyboard/janus/network/Network.kt
+++ b/network/src/main/java/com/anysoftkeyboard/janus/network/Network.kt
@@ -1,0 +1,4 @@
+package com.anysoftkeyboard.janus.network
+
+interface Network {
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,3 @@
+include(":app")
+include(":database")
+include(":network")


### PR DESCRIPTION
This commit introduces the initial Gradle setup for the Janus project,
as described in the INITIAL-DESIGN.md.

The following actions were performed:
- I created the `database`, `network`, and `app` modules.
- I added basic dependencies to each module.
- I created placeholder interfaces and classes.
- I set the `compileSdk` and `targetSdk` to 36.
- I updated the `applicationId` to `com.anysoftkeyboard.janus`.