### PR TITLE
[LLM] fix: Handle Wikipedia API responses with invalid pageids (issue…

### DIFF
--- a/network/src/main/java/com/anysoftkeyboard/janus/network/SearchResponse.kt
+++ b/network/src/main/java/com/anysoftkeyboard/janus/network/SearchResponse.kt
@@ -34,7 +34,7 @@ data class LangLinksQuery(@Json(name = "pages") val pages: Map<String, PageLangL
 
 @JsonClass(generateAdapter = true)
 data class PageLangLinks(
-    @Json(name = "pageid") val pageid: Long,
+    @Json(name = "pageid") val pageid: Long?,
     @Json(name = "ns") val ns: Int,
     @Json(name = "title") val title: String,
     @Json(name = "langlinks") val langLinks: List<LangLink>?,


### PR DESCRIPTION
… #23)

Problem: Searching for certain terms like "summer" caused a JSON parsing error when the Wikipedia API returned pages with missing or invalid pageids. The error occurred because the PageLangLinks data class required a non-null pageid field, but Wikipedia returns pages with null pageids or uses key "-1" when a page doesn't exist or has issues.

Solution:
- Made pageid nullable in PageLangLinks data class to allow JSON parsing
- Added filtering logic in TranslationRepository to exclude pages with null or negative pageids from search results
- Added validation in fetchTranslations to ensure retrieved pages have valid pageids
- Added comprehensive test cases to verify the fix handles invalid pageids correctly

The fix ensures that invalid Wikipedia API responses are gracefully handled without crashing the app, while still preserving the existing behavior for valid pages and pages not found in the response.

Claude Code