### PR TITLE
Fix crash when switching languages in translation screen

### DIFF
--- a/app/src/main/java/com/anysoftkeyboard/janus/app/ui/TranslateScreen.kt
+++ b/app/src/main/java/com/anysoftkeyboard/janus/app/ui/TranslateScreen.kt
@@ -91,7 +91,11 @@ fun TranslateScreen(viewModel: TranslateViewModel) {
                   sourceLang = newSource
                   targetLang = newTarget
                   text = newSearchTerm
-                  viewModel.searchArticles("", "")
+                  if (newSearchTerm.isNotEmpty()) {
+                    viewModel.searchArticles(newSource, newSearchTerm)
+                  } else {
+                    viewModel.clearSearch()
+                  }
                 })
 
             Spacer(modifier = Modifier.height(16.dp))

--- a/app/src/main/java/com/anysoftkeyboard/janus/app/viewmodels/TranslateViewModel.kt
+++ b/app/src/main/java/com/anysoftkeyboard/janus/app/viewmodels/TranslateViewModel.kt
@@ -76,6 +76,10 @@ constructor(
   private var previousSearchResults: TranslateViewState.OptionsFetched? = null
 
   fun searchArticles(sourceLang: String, term: String) {
+    if (sourceLang.isEmpty()) {
+      Log.w("TranslateViewModel", "searchArticles called with empty sourceLang")
+      return
+    }
     _state.value = TranslateViewState.FetchingOptions
     viewModelScope.launch {
       try {

--- a/app/src/test/java/com/anysoftkeyboard/janus/app/viewmodels/TranslateViewModelTest.kt
+++ b/app/src/test/java/com/anysoftkeyboard/janus/app/viewmodels/TranslateViewModelTest.kt
@@ -129,6 +129,18 @@ class TranslateViewModelTest {
   }
 
   @Test
+  fun `searchArticles with empty source language does nothing`() = runTest {
+    viewModel.pageState.test {
+      assertEquals(TranslateViewState.Empty, awaitItem())
+
+      viewModel.searchArticles("", "term")
+
+      // Should not emit FetchingOptions or any other state
+      expectNoEvents()
+    }
+  }
+
+  @Test
   fun `fetchTranslation success with target language available`() = runTest {
     val searchTerm =
         OptionalSourceTerm(


### PR DESCRIPTION
Prevents an IllegalArgumentException by ensuring valid language codes are passed during language swap and adding a safety check in the ViewModel.