### PR TITLE
[LLM] Add Renovate bot configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["gradle", "gradle-wrapper"],
+      "groupName": "Gradle dependencies",
+      "schedule": ["every weekend"]
+    },
+    {
+      "matchPackagePatterns": ["^androidx\\."],
+      "groupName": "AndroidX dependencies",
+      "schedule": ["every weekend"]
+    },
+    {
+      "matchPackagePatterns": ["^com\\.google\\.android"],
+      "groupName": "Google Android dependencies",
+      "schedule": ["every weekend"]
+    },
+    {
+      "matchPackagePatterns": ["^org\\.jetbrains\\.kotlin"],
+      "groupName": "Kotlin dependencies",
+      "schedule": ["every weekend"]
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    }
+  ],
+  "gradle": {
+    "enabled": true
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"],
+    "assignees": []
+  },
+  "labels": ["dependencies"],
+  "rangeStrategy": "bump",
+  "semanticCommits": "disabled",
+  "prConcurrentLimit": 3,
+  "prHourlyLimit": 0,
+  "timezone": "UTC",
+  "assignees": [],
+  "reviewers": []
+}


### PR DESCRIPTION
## Summary
- Adds Renovate bot configuration to automate dependency updates
- Enables grouped dependency updates by category (Gradle, AndroidX, Google Android, Kotlin)
- Schedules updates for weekends to avoid disrupting weekday development
- Enables security vulnerability alerts with automatic PR creation
- Configures rate limiting to prevent overwhelming the repository with PRs

## Configuration Details
- **Dependency Grouping**: Related dependencies are grouped into single PRs for easier review
- **Weekend Scheduling**: Non-security updates only run on weekends
- **Security Alerts**: Immediate PRs for dependencies with known vulnerabilities
- **Rate Limiting**: Maximum 3 concurrent PRs to keep the repository manageable
- **Automerge**: Dev dependencies can be automatically merged

## Test plan
- [x] Configuration file created and validated
- [x] Formatting applied with `./gradlew spotlessApply`
- [ ] Enable Renovate bot in GitHub repository settings
- [ ] Monitor first Renovate run to ensure configuration works as expected

Implements #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)