### PR TITLE
[LLM] Migrate AI Review to Cassandra v0.5.0 and cassandra.toml

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -16,10 +16,8 @@ jobs:
           fetch-depth: 0 # Important: fetch all history for diffing
 
       - name: Run Cassandra AI Review
-        uses: menny/cassandra@0e02fd244b1c8c1e3a41a8aefb14bf1d367a11ad
+        uses: menny/cassandra@v0.5.0
         with:
-          provider: 'google'
-          model_id: 'gemini-3-flash-preview'
           provider_api_key: ${{ secrets.GEMINI_2_5_FLASH_API_KEY }}
           # The base branch to compare against (defaults to main)
           base: ${{ github.event.pull_request.base.sha }}

--- a/cassandra.toml
+++ b/cassandra.toml
@@ -1,0 +1,2 @@
+provider = "google"
+model = "gemini-3-flash-preview"


### PR DESCRIPTION
This commit migrates the pull request review workflow to use the latest released version of Cassandra (v0.5.0) and centralizes settings into a cassandra.toml configuration file.

What:
- Created a new cassandra.toml file in the repository root containing the provider and model settings.
- Updated .github/workflows/review.yml to use menny/cassandra@v0.5.0 and removed duplicate provider/model_id inputs.

Why:
- Using cassandra.toml centralizes configuration settings, making the workflow configuration cleaner and easier to manage.
- Upgrading to v0.5.0 ensures the project uses the latest stable capabilities of the review agent.

Antigravity