### PR TITLE
[LLM] Show related articles in translation view

### DIFF
--- a/app/src/main/java/com/anysoftkeyboard/janus/app/repository/TranslationRepository.kt
+++ b/app/src/main/java/com/anysoftkeyboard/janus/app/repository/TranslationRepository.kt
@@ -205,7 +205,12 @@ open class TranslationRepository(
       limit: Int = 8,
   ): List<RelatedArticle> {
     val api = wikipediaApi.createWikipediaApi(sourceLang)
-    val response = api.getRelatedArticles(morelikeQuery = "morelike:$sourceTitle", limit = limit)
+    // MediaWiki canonical title form: multi-word titles use underscores.
+    val response =
+        api.getRelatedArticles(
+            morelikeQuery = "morelike:${sourceTitle.replace(' ', '_')}",
+            limit = limit,
+        )
     return response.query
         ?.pages
         ?.values

--- a/app/src/main/java/com/anysoftkeyboard/janus/app/repository/TranslationRepository.kt
+++ b/app/src/main/java/com/anysoftkeyboard/janus/app/repository/TranslationRepository.kt
@@ -15,6 +15,21 @@ data class OptionalSourceTerm(
     val availableLanguages: List<String>,
 )
 
+data class RelatedArticle(
+    val pageid: Long,
+    val title: String,
+    val shortDescription: String?,
+    val extract: String?,
+) {
+  fun toOptionalSourceTerm(): OptionalSourceTerm =
+      OptionalSourceTerm(
+          pageid = pageid,
+          title = title,
+          snippet = extract ?: "",
+          availableLanguages = emptyList(),
+      )
+}
+
 open class TranslationRepository(
     private val translationDao: TranslationDao,
     private val wikipediaApi: LangWikipediaFactory,
@@ -181,6 +196,38 @@ open class TranslationRepository(
           )
         }
         .also { it.forEach { t -> translationDao.insertTranslation(t) } }
+  }
+
+  open suspend fun getRelatedArticles(
+      sourceLang: String,
+      sourceTitle: String,
+      sourcePageId: Long,
+      limit: Int = 8,
+  ): List<RelatedArticle> {
+    val api = wikipediaApi.createWikipediaApi(sourceLang)
+    val response = api.getRelatedArticles(morelikeQuery = "morelike:$sourceTitle", limit = limit)
+    return response.query
+        ?.pages
+        ?.values
+        ?.asSequence()
+        ?.filter { page -> page.ns == 0 }
+        ?.mapNotNull { page ->
+          val pageId = page.pageid
+          if (pageId == null || pageId <= 0 || pageId == sourcePageId) {
+            null
+          } else if (page.pageProps?.disambiguation != null) {
+            null
+          } else {
+            RelatedArticle(
+                pageid = pageId,
+                title = page.title,
+                shortDescription = page.pageProps?.wikibaseShortdesc,
+                extract = page.extract,
+            )
+          }
+        }
+        ?.take(limit)
+        ?.toList() ?: emptyList()
   }
 
   open suspend fun deleteTranslation(id: Int) {

--- a/app/src/main/java/com/anysoftkeyboard/janus/app/ui/TranslateScreen.kt
+++ b/app/src/main/java/com/anysoftkeyboard/janus/app/ui/TranslateScreen.kt
@@ -71,6 +71,7 @@ fun TranslateScreen(viewModel: TranslateViewModel, initialSearchTerm: String? = 
 
   val recentLanguages by viewModel.recentLanguages.collectAsState()
   val welcomeMessage by viewModel.welcomeMessage.collectAsState()
+  val relatedState by viewModel.relatedArticles.collectAsState()
   val snackbarHostState = remember { SnackbarHostState() }
   val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -205,6 +206,14 @@ fun TranslateScreen(viewModel: TranslateViewModel, initialSearchTerm: String? = 
                     translated = targetState,
                     sharedTransitionScope = this@SharedTransitionLayout,
                     animatedVisibilityScope = this,
+                    relatedState = relatedState,
+                    onRelatedClick = { related ->
+                      viewModel.fetchRelatedTranslation(
+                          related,
+                          targetState.sourceLang,
+                          targetState.targetLang,
+                      )
+                    },
                 )
             is TranslateViewState.Error -> ErrorStateDisplay(error = targetState)
             is TranslateViewState.AmbiguousSource -> {

--- a/app/src/main/java/com/anysoftkeyboard/janus/app/ui/states/TranslationView.kt
+++ b/app/src/main/java/com/anysoftkeyboard/janus/app/ui/states/TranslationView.kt
@@ -3,6 +3,7 @@ package com.anysoftkeyboard.janus.app.ui.states
 import androidx.compose.animation.AnimatedVisibilityScope
 import androidx.compose.animation.ExperimentalSharedTransitionApi
 import androidx.compose.animation.SharedTransitionScope
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -11,7 +12,9 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
@@ -19,14 +22,18 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.anysoftkeyboard.janus.app.R
+import com.anysoftkeyboard.janus.app.repository.RelatedArticle
 import com.anysoftkeyboard.janus.app.ui.components.CopyToClipboardButton
 import com.anysoftkeyboard.janus.app.ui.components.HtmlText
+import com.anysoftkeyboard.janus.app.ui.components.JanusLoader
 import com.anysoftkeyboard.janus.app.ui.components.PivotConnector
 import com.anysoftkeyboard.janus.app.ui.components.WikipediaLinkButton
+import com.anysoftkeyboard.janus.app.viewmodels.RelatedArticlesState
 import com.anysoftkeyboard.janus.app.viewmodels.TranslateViewState
 import com.anysoftkeyboard.janus.app.viewmodels.TranslationState
 
@@ -47,8 +54,10 @@ fun TranslationView(
     translated: TranslateViewState.Translated,
     sharedTransitionScope: SharedTransitionScope? = null,
     animatedVisibilityScope: AnimatedVisibilityScope? = null,
+    relatedState: RelatedArticlesState = RelatedArticlesState.Hidden,
+    onRelatedClick: ((RelatedArticle) -> Unit)? = null,
 ) {
-  Column(modifier = Modifier.fillMaxWidth()) {
+  Column(modifier = Modifier.fillMaxWidth().verticalScroll(rememberScrollState())) {
     SourceArticleSection(
         title = translated.term.title,
         language = translated.sourceLang,
@@ -63,6 +72,12 @@ fun TranslationView(
     )
 
     TranslationContent(translation = translated.translation, targetLang = translated.targetLang)
+
+    RelatedArticlesSection(
+        relatedState = relatedState,
+        sourceLang = translated.sourceLang,
+        onRelatedClick = onRelatedClick,
+    )
   }
 }
 
@@ -262,4 +277,101 @@ private fun UnknownStateContent(translation: TranslationState) {
       text = "Unknown state type: ${translation.javaClass}",
       style = MaterialTheme.typography.bodyMedium,
   )
+}
+
+/** Inline section showing articles related to the translated source article. */
+@Composable
+private fun RelatedArticlesSection(
+    relatedState: RelatedArticlesState,
+    sourceLang: String,
+    onRelatedClick: ((RelatedArticle) -> Unit)?,
+) {
+  when (relatedState) {
+    is RelatedArticlesState.Hidden -> {
+      // Do not disturb the translation view when related articles are unavailable.
+    }
+    is RelatedArticlesState.Loading -> {
+      Spacer(modifier = Modifier.height(8.dp))
+      Row(
+          modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+          verticalAlignment = Alignment.CenterVertically,
+      ) {
+        JanusLoader(modifier = Modifier.size(48.dp))
+        Text(
+            text = stringResource(R.string.related_articles_loading),
+            style = MaterialTheme.typography.labelMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+    }
+    is RelatedArticlesState.Loaded -> {
+      Spacer(modifier = Modifier.height(16.dp))
+      Text(
+          text = stringResource(R.string.related_articles_title),
+          style = MaterialTheme.typography.labelLarge,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+      Spacer(modifier = Modifier.height(8.dp))
+      relatedState.articles.forEach { article ->
+        RelatedArticleItem(
+            article = article,
+            sourceLang = sourceLang,
+            onClick = onRelatedClick?.let { callback -> { callback(article) } },
+        )
+      }
+    }
+  }
+}
+
+/** Card displaying a single related article. Tapping it translates that concept directly. */
+@Composable
+private fun RelatedArticleItem(
+    article: RelatedArticle,
+    sourceLang: String,
+    onClick: (() -> Unit)?,
+) {
+  Card(
+      modifier =
+          Modifier.fillMaxWidth().padding(vertical = 4.dp).testTag("related_article_item").let {
+              modifier ->
+            if (onClick != null) modifier.clickable(onClick = onClick) else modifier
+          },
+      colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+      shape = MaterialTheme.shapes.medium,
+  ) {
+    Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+      Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.CenterVertically) {
+        Text(
+            text = article.title,
+            style = MaterialTheme.typography.titleLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f).horizontalScroll(rememberScrollState()),
+        )
+        WikipediaLinkButton(
+            url = "https://${sourceLang}.wikipedia.org/?curid=${article.pageid}",
+            contentDescription = stringResource(R.string.content_description_open_wikipedia),
+        )
+      }
+      article.shortDescription?.let { description ->
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = description,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+      }
+      article.extract?.let { extract ->
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(
+            text = extract,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+            maxLines = 3,
+            overflow = TextOverflow.Ellipsis,
+        )
+      }
+    }
+  }
 }

--- a/app/src/main/java/com/anysoftkeyboard/janus/app/viewmodels/TranslateViewModel.kt
+++ b/app/src/main/java/com/anysoftkeyboard/janus/app/viewmodels/TranslateViewModel.kt
@@ -15,6 +15,8 @@ import com.anysoftkeyboard.janus.app.util.TranslationFlowMessagesProvider
 import com.anysoftkeyboard.janus.database.entities.Translation
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
@@ -116,10 +118,10 @@ constructor(
 
   private val _state = MutableStateFlow<TranslateViewState>(TranslateViewState.Empty)
   val pageState: StateFlow<TranslateViewState> = _state
-
   private val _relatedArticles = MutableStateFlow<RelatedArticlesState>(RelatedArticlesState.Hidden)
   val relatedArticles: StateFlow<RelatedArticlesState> = _relatedArticles
   private val relatedCache = mutableMapOf<Pair<String, Long>, List<RelatedArticle>>()
+  private var relatedArticlesJob: Job? = null
 
   private val _welcomeMessage = MutableStateFlow(welcomeMessageProvider.getRandomMessage())
   val welcomeMessage: StateFlow<TranslationFlowMessages> = _welcomeMessage
@@ -187,6 +189,7 @@ constructor(
   }
 
   private suspend fun performSearch(sourceLang: String, term: String) {
+    cancelRelatedArticlesLoad()
     _relatedArticles.value = RelatedArticlesState.Hidden
     _state.value =
         TranslateViewState.OptionsFetched(
@@ -265,6 +268,7 @@ constructor(
   }
 
   private fun loadRelatedArticles(sourceLang: String, term: OptionalSourceTerm) {
+    cancelRelatedArticlesLoad()
     val key = sourceLang to term.pageid
     relatedCache[key]?.let { cached ->
       _relatedArticles.value =
@@ -276,21 +280,40 @@ constructor(
       return
     }
     _relatedArticles.value = RelatedArticlesState.Loading
-    viewModelScope.launch {
-      try {
-        val related = repository.getRelatedArticles(sourceLang, term.title, term.pageid)
-        relatedCache[key] = related
-        _relatedArticles.value =
-            if (related.isEmpty()) {
-              RelatedArticlesState.Hidden
-            } else {
-              RelatedArticlesState.Loaded(related)
+    relatedArticlesJob =
+        viewModelScope.launch {
+          try {
+            val related = repository.getRelatedArticles(sourceLang, term.title, term.pageid)
+            relatedCache[key] = related
+            if (isShowingTranslationOf(sourceLang, term.pageid)) {
+              _relatedArticles.value =
+                  if (related.isEmpty()) {
+                    RelatedArticlesState.Hidden
+                  } else {
+                    RelatedArticlesState.Loaded(related)
+                  }
             }
-      } catch (e: Exception) {
-        Log.w("TranslateViewModel", "Error fetching related articles", e)
-        _relatedArticles.value = RelatedArticlesState.Hidden
-      }
-    }
+          } catch (e: CancellationException) {
+            throw e
+          } catch (e: Exception) {
+            Log.w("TranslateViewModel", "Error fetching related articles", e)
+            if (isShowingTranslationOf(sourceLang, term.pageid)) {
+              _relatedArticles.value = RelatedArticlesState.Hidden
+            }
+          }
+        }
+  }
+
+  private fun isShowingTranslationOf(sourceLang: String, pageId: Long): Boolean {
+    val current = _state.value
+    return current is TranslateViewState.Translated &&
+        current.sourceLang == sourceLang &&
+        current.term.pageid == pageId
+  }
+
+  private fun cancelRelatedArticlesLoad() {
+    relatedArticlesJob?.cancel()
+    relatedArticlesJob = null
   }
 
   private fun mapToErrorType(e: Exception): ErrorType {
@@ -315,12 +338,14 @@ constructor(
    * exist, clears to Empty state.
    */
   fun backToSearchResults() {
+    cancelRelatedArticlesLoad()
     _relatedArticles.value = RelatedArticlesState.Hidden
     previousSearchResults?.let { _state.value = it } ?: run { clearSearch() }
   }
 
   /** Clear search and return to Empty state. Also clears saved search results. */
   fun clearSearch() {
+    cancelRelatedArticlesLoad()
     _state.value = TranslateViewState.Empty
     _relatedArticles.value = RelatedArticlesState.Hidden
     relatedCache.clear()

--- a/app/src/main/java/com/anysoftkeyboard/janus/app/viewmodels/TranslateViewModel.kt
+++ b/app/src/main/java/com/anysoftkeyboard/janus/app/viewmodels/TranslateViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.anysoftkeyboard.janus.app.repository.OptionalSourceTerm
 import com.anysoftkeyboard.janus.app.repository.RecentLanguagesRepository
+import com.anysoftkeyboard.janus.app.repository.RelatedArticle
 import com.anysoftkeyboard.janus.app.repository.TranslationRepository
 import com.anysoftkeyboard.janus.app.util.DetectionResult
 import com.anysoftkeyboard.janus.app.util.LanguageDetector
@@ -29,6 +30,14 @@ sealed class TranslationState() {
   ) : TranslationState()
 
   data class Error(val errorMessage: String) : TranslationState()
+}
+
+sealed interface RelatedArticlesState {
+  data object Hidden : RelatedArticlesState
+
+  data object Loading : RelatedArticlesState
+
+  data class Loaded(val articles: List<RelatedArticle>) : RelatedArticlesState
 }
 
 sealed class TranslateViewState() {
@@ -108,6 +117,10 @@ constructor(
   private val _state = MutableStateFlow<TranslateViewState>(TranslateViewState.Empty)
   val pageState: StateFlow<TranslateViewState> = _state
 
+  private val _relatedArticles = MutableStateFlow<RelatedArticlesState>(RelatedArticlesState.Hidden)
+  val relatedArticles: StateFlow<RelatedArticlesState> = _relatedArticles
+  private val relatedCache = mutableMapOf<Pair<String, Long>, List<RelatedArticle>>()
+
   private val _welcomeMessage = MutableStateFlow(welcomeMessageProvider.getRandomMessage())
   val welcomeMessage: StateFlow<TranslationFlowMessages> = _welcomeMessage
 
@@ -174,6 +187,7 @@ constructor(
   }
 
   private suspend fun performSearch(sourceLang: String, term: String) {
+    _relatedArticles.value = RelatedArticlesState.Hidden
     _state.value =
         TranslateViewState.OptionsFetched(
             term,
@@ -221,10 +235,60 @@ constructor(
                 targetLang,
                 translationState,
             )
+        loadRelatedArticles(sources.effectiveSourceLang, searchPage)
       } catch (e: Exception) {
         Log.e("TranslateViewModel", "Error fetching translation", e)
+        _relatedArticles.value = RelatedArticlesState.Hidden
         val errorType = mapToErrorType(e)
         _state.value = TranslateViewState.Error(errorType, e.message)
+      }
+    }
+  }
+
+  fun fetchRelatedTranslation(related: RelatedArticle, sourceLang: String, targetLang: String) {
+    val term = related.toOptionalSourceTerm()
+    val sources =
+        previousSearchResults?.let { previous ->
+          if (previous.options.any { it.pageid == term.pageid }) {
+            previous
+          } else {
+            previous.copy(options = previous.options + term)
+          }
+        }
+            ?: TranslateViewState.OptionsFetched(
+                searchTerm = related.title,
+                options = listOf(term),
+                translations = emptyMap(),
+                effectiveSourceLang = sourceLang,
+            )
+    fetchTranslation(sources, term, targetLang)
+  }
+
+  private fun loadRelatedArticles(sourceLang: String, term: OptionalSourceTerm) {
+    val key = sourceLang to term.pageid
+    relatedCache[key]?.let { cached ->
+      _relatedArticles.value =
+          if (cached.isEmpty()) {
+            RelatedArticlesState.Hidden
+          } else {
+            RelatedArticlesState.Loaded(cached)
+          }
+      return
+    }
+    _relatedArticles.value = RelatedArticlesState.Loading
+    viewModelScope.launch {
+      try {
+        val related = repository.getRelatedArticles(sourceLang, term.title, term.pageid)
+        relatedCache[key] = related
+        _relatedArticles.value =
+            if (related.isEmpty()) {
+              RelatedArticlesState.Hidden
+            } else {
+              RelatedArticlesState.Loaded(related)
+            }
+      } catch (e: Exception) {
+        Log.w("TranslateViewModel", "Error fetching related articles", e)
+        _relatedArticles.value = RelatedArticlesState.Hidden
       }
     }
   }
@@ -251,12 +315,15 @@ constructor(
    * exist, clears to Empty state.
    */
   fun backToSearchResults() {
+    _relatedArticles.value = RelatedArticlesState.Hidden
     previousSearchResults?.let { _state.value = it } ?: run { clearSearch() }
   }
 
   /** Clear search and return to Empty state. Also clears saved search results. */
   fun clearSearch() {
     _state.value = TranslateViewState.Empty
+    _relatedArticles.value = RelatedArticlesState.Hidden
+    relatedCache.clear()
     previousSearchResults = null
     _welcomeMessage.value = welcomeMessageProvider.getRandomMessage()
   }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -67,6 +67,10 @@
     <!-- Search results -->
     <string name="search_results_untranslated_section">مقالات غير مترجمة</string>
 
+    <!-- Related articles -->
+    <string name="related_articles_title">مقالات ذات صلة</string>
+    <string name="related_articles_loading">جارٍ البحث عن مقالات ذات صلة...</string>
+
     <!-- Translation view -->
     <string name="translation_not_available">الترجمة غير متوفرة لـ %1$s</string>
     <string name="available_translations">الترجمات المتاحة: %1$s</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -67,6 +67,10 @@
     <!-- Search results -->
     <string name="search_results_untranslated_section">Nicht übersetzte Artikel</string>
 
+    <!-- Related articles -->
+    <string name="related_articles_title">Verwandte Artikel</string>
+    <string name="related_articles_loading">Verwandte Artikel werden gesucht...</string>
+
     <!-- Translation view -->
     <string name="translation_not_available">Übersetzung nicht verfügbar für %1$s</string>
     <string name="available_translations">Verfügbare Übersetzungen: %1$s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -67,6 +67,10 @@
     <!-- Search results -->
     <string name="search_results_untranslated_section">Artículos sin traducir</string>
 
+    <!-- Related articles -->
+    <string name="related_articles_title">Artículos relacionados</string>
+    <string name="related_articles_loading">Buscando artículos relacionados...</string>
+
     <!-- Translation view -->
     <string name="translation_not_available">Traducción no disponible para %1$s</string>
     <string name="available_translations">Traducciones disponibles: %1$s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -67,6 +67,10 @@
     <!-- Search results -->
     <string name="search_results_untranslated_section">Articles non traduits</string>
 
+    <!-- Related articles -->
+    <string name="related_articles_title">Articles connexes</string>
+    <string name="related_articles_loading">Recherche d\'articles connexes...</string>
+
     <!-- Translation view -->
     <string name="translation_not_available">Traduction non disponible pour %1$s</string>
     <string name="available_translations">Traductions disponibles : %1$s</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -67,6 +67,10 @@
     <!-- Search results -->
     <string name="search_results_untranslated_section">מאמרים לא מתורגמים</string>
 
+    <!-- Related articles -->
+    <string name="related_articles_title">מאמרים קשורים</string>
+    <string name="related_articles_loading">מחפש מאמרים קשורים...</string>
+
     <!-- Translation view -->
     <string name="translation_not_available">תרגום לא זמין עבור %1$s</string>
     <string name="available_translations">תרגומים זמינים: %1$s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -67,6 +67,10 @@
     <!-- Search results -->
     <string name="search_results_untranslated_section">Непереведённые статьи</string>
 
+    <!-- Related articles -->
+    <string name="related_articles_title">Похожие статьи</string>
+    <string name="related_articles_loading">Поиск похожих статей...</string>
+
     <!-- Translation view -->
     <string name="translation_not_available">Перевод недоступен для %1$s</string>
     <string name="available_translations">Доступные переводы: %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,6 +80,10 @@
     <!-- Search results -->
     <string name="search_results_untranslated_section">Untranslated Articles</string>
 
+    <!-- Related articles -->
+    <string name="related_articles_title">Related articles</string>
+    <string name="related_articles_loading">Finding related articles...</string>
+
     <!-- Translation view -->
     <string name="translation_not_available">Translation not available for %1$s</string>
     <string name="available_translations">Available translations: %1$s</string>

--- a/app/src/test/java/com/anysoftkeyboard/janus/app/repository/FakeTranslationRepository.kt
+++ b/app/src/test/java/com/anysoftkeyboard/janus/app/repository/FakeTranslationRepository.kt
@@ -22,8 +22,11 @@ constructor(
   private val _bookmarks = MutableStateFlow(emptyList<Translation>())
   var nextSearchResults: List<OptionalSourceTerm> = emptyList()
   var nextTranslations: List<Translation> = emptyList()
+  var nextRelatedArticles: List<RelatedArticle> = emptyList()
   var searchException: Exception? = null
   var fetchException: Exception? = null
+  var relatedException: Exception? = null
+  var getRelatedArticleCalls = 0
 
   override fun getHistory(): Flow<List<Translation>> = _history.asStateFlow()
 
@@ -50,6 +53,17 @@ constructor(
   ): List<Translation> {
     fetchException?.let { throw it }
     return nextTranslations
+  }
+
+  override suspend fun getRelatedArticles(
+      sourceLang: String,
+      sourceTitle: String,
+      sourcePageId: Long,
+      limit: Int,
+  ): List<RelatedArticle> {
+    relatedException?.let { throw it }
+    getRelatedArticleCalls++
+    return nextRelatedArticles
   }
 
   fun setHistory(history: List<Translation>) {

--- a/app/src/test/java/com/anysoftkeyboard/janus/app/repository/FakeTranslationRepository.kt
+++ b/app/src/test/java/com/anysoftkeyboard/janus/app/repository/FakeTranslationRepository.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
 
-class FakeTranslationRepository
+open class FakeTranslationRepository
 @Inject
 constructor(
     private val translationDao: TranslationDao,

--- a/app/src/test/java/com/anysoftkeyboard/janus/app/repository/TranslationRepositoryTest.kt
+++ b/app/src/test/java/com/anysoftkeyboard/janus/app/repository/TranslationRepositoryTest.kt
@@ -994,4 +994,15 @@ class TranslationRepositoryTest {
     assertEquals(2, result.size)
     verify(wikipediaApi).getRelatedArticles("morelike:Cat", 2)
   }
+
+  @Test
+  fun `test getRelatedArticles normalizes multi-word titles to underscores`() = runTest {
+    whenever(wikipediaApi.getRelatedArticles(any(), any()))
+        .thenReturn(LangLinksResponse(query = null))
+
+    val result = repository.getRelatedArticles("en", "New York City", 1L)
+
+    assertEquals(0, result.size)
+    verify(wikipediaApi).getRelatedArticles("morelike:New_York_City", 8)
+  }
 }

--- a/app/src/test/java/com/anysoftkeyboard/janus/app/repository/TranslationRepositoryTest.kt
+++ b/app/src/test/java/com/anysoftkeyboard/janus/app/repository/TranslationRepositoryTest.kt
@@ -846,4 +846,152 @@ class TranslationRepositoryTest {
         assertEquals("Cat", result[0].title)
         assertEquals(listOf("he"), result[0].availableLanguages)
       }
+
+  @Test
+  fun `test getRelatedArticles returns mapped articles`() = runTest {
+    val kittenPage =
+        PageLangLinks(
+            pageid = 2,
+            ns = 0,
+            title = "Kitten",
+            langLinks = null,
+            pageProps = PageProps(disambiguation = null, wikibaseShortdesc = "Young cat"),
+            links = null,
+            extract = "A kitten is a juvenile cat.",
+        )
+    val purrPage =
+        PageLangLinks(
+            pageid = 3,
+            ns = 0,
+            title = "Purr",
+            langLinks = null,
+            pageProps =
+                PageProps(disambiguation = null, wikibaseShortdesc = "Fluttering vocalization"),
+            links = null,
+            extract = "A purr is a tonal fluttering sound.",
+        )
+    val response =
+        LangLinksResponse(query = LangLinksQuery(pages = mapOf("2" to kittenPage, "3" to purrPage)))
+
+    whenever(wikipediaApi.getRelatedArticles(any(), any())).thenReturn(response)
+
+    val result = repository.getRelatedArticles("en", "Cat", 1L)
+
+    assertEquals(2, result.size)
+    assertEquals("Kitten", result[0].title)
+    assertEquals(2L, result[0].pageid)
+    assertEquals("Young cat", result[0].shortDescription)
+    assertEquals("A kitten is a juvenile cat.", result[0].extract)
+    assertEquals("Purr", result[1].title)
+    verify(wikipediaApi).getRelatedArticles("morelike:Cat", 8)
+  }
+
+  @Test
+  fun `test getRelatedArticles filters source page invalid pages and disambiguation`() = runTest {
+    val selfPage =
+        PageLangLinks(
+            pageid = 1,
+            ns = 0,
+            title = "Cat",
+            langLinks = null,
+            pageProps = null,
+            links = null,
+            extract = "The cat is a domestic species.",
+        )
+    val validPage =
+        PageLangLinks(
+            pageid = 2,
+            ns = 0,
+            title = "Kitten",
+            langLinks = null,
+            pageProps = null,
+            links = null,
+            extract = "A kitten is a juvenile cat.",
+        )
+    val disambPage =
+        PageLangLinks(
+            pageid = 3,
+            ns = 0,
+            title = "Cat (disambiguation)",
+            langLinks = null,
+            pageProps = PageProps(disambiguation = "", wikibaseShortdesc = null),
+            links = null,
+            extract = null,
+        )
+    val nonMainNamespacePage =
+        PageLangLinks(
+            pageid = 4,
+            ns = 1,
+            title = "Talk:Cat",
+            langLinks = null,
+            pageProps = null,
+            links = null,
+            extract = null,
+        )
+    val invalidPage =
+        PageLangLinks(
+            pageid = null,
+            ns = 0,
+            title = "Missing",
+            langLinks = null,
+            pageProps = null,
+            links = null,
+            extract = null,
+        )
+    val response =
+        LangLinksResponse(
+            query =
+                LangLinksQuery(
+                    pages =
+                        mapOf(
+                            "1" to selfPage,
+                            "2" to validPage,
+                            "3" to disambPage,
+                            "4" to nonMainNamespacePage,
+                            "5" to invalidPage,
+                        )
+                )
+        )
+
+    whenever(wikipediaApi.getRelatedArticles(any(), any())).thenReturn(response)
+
+    val result = repository.getRelatedArticles("en", "Cat", 1L)
+
+    assertEquals(1, result.size)
+    assertEquals("Kitten", result[0].title)
+  }
+
+  @Test
+  fun `test getRelatedArticles with null query returns empty list`() = runTest {
+    whenever(wikipediaApi.getRelatedArticles(any(), any()))
+        .thenReturn(LangLinksResponse(query = null))
+
+    val result = repository.getRelatedArticles("en", "Cat", 1L)
+
+    assertEquals(0, result.size)
+  }
+
+  @Test
+  fun `test getRelatedArticles respects limit`() = runTest {
+    val pages =
+        (10..14).associate { id ->
+          id.toString() to
+              PageLangLinks(
+                  pageid = id.toLong(),
+                  ns = 0,
+                  title = "Article $id",
+                  langLinks = null,
+                  pageProps = null,
+                  links = null,
+                  extract = null,
+              )
+        }
+    whenever(wikipediaApi.getRelatedArticles(any(), any()))
+        .thenReturn(LangLinksResponse(query = LangLinksQuery(pages = pages)))
+
+    val result = repository.getRelatedArticles("en", "Cat", 1L, limit = 2)
+
+    assertEquals(2, result.size)
+    verify(wikipediaApi).getRelatedArticles("morelike:Cat", 2)
+  }
 }

--- a/app/src/test/java/com/anysoftkeyboard/janus/app/viewmodels/TranslateViewModelTest.kt
+++ b/app/src/test/java/com/anysoftkeyboard/janus/app/viewmodels/TranslateViewModelTest.kt
@@ -2,6 +2,7 @@ package com.anysoftkeyboard.janus.app.viewmodels
 
 import app.cash.turbine.test
 import com.anysoftkeyboard.janus.app.R
+import com.anysoftkeyboard.janus.app.di.LangWikipediaFactory
 import com.anysoftkeyboard.janus.app.repository.FakeTranslationRepository
 import com.anysoftkeyboard.janus.app.repository.OptionalSourceTerm
 import com.anysoftkeyboard.janus.app.repository.RecentLanguagesRepository
@@ -9,9 +10,12 @@ import com.anysoftkeyboard.janus.app.repository.RelatedArticle
 import com.anysoftkeyboard.janus.app.util.DetectionResult
 import com.anysoftkeyboard.janus.app.util.FakeStringProvider
 import com.anysoftkeyboard.janus.app.util.LanguageDetector
+import com.anysoftkeyboard.janus.app.util.StringProvider
 import com.anysoftkeyboard.janus.app.util.TranslationFlowMessages
 import com.anysoftkeyboard.janus.app.util.TranslationFlowMessagesProvider
+import com.anysoftkeyboard.janus.database.dao.TranslationDao
 import com.anysoftkeyboard.janus.database.entities.Translation
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -941,5 +945,128 @@ class TranslateViewModelTest {
 
     assertEquals(1, fakeRepository.getRelatedArticleCalls)
     assertTrue(viewModel.relatedArticles.value is RelatedArticlesState.Loaded)
+  }
+
+  @Test
+  fun `stale related results are discarded when translation changes`() = runTest {
+    val gated = GatedFakeTranslationRepository(mock(), mock(), FakeStringProvider())
+    val gatedViewModel =
+        TranslateViewModel(
+            gated,
+            mockRecentLanguagesRepository,
+            FakeStringProvider(),
+            mockWelcomeMessageProvider,
+            mockLanguageDetector,
+        )
+    val translation =
+        Translation(
+            sourceWord = "Cat",
+            sourceLangCode = "en",
+            sourceArticleUrl = "url",
+            sourceShortDescription = "desc",
+            sourceSummary = "summary",
+            translatedWord = "חתול",
+            targetLangCode = "he",
+            targetArticleUrl = "url_he",
+            targetShortDescription = "desc_he",
+            targetSummary = "summary_he",
+        )
+    gated.nextTranslations = listOf(translation)
+    val termA = OptionalSourceTerm(1, "Cat", "domestic species", listOf("he"))
+    val termB = OptionalSourceTerm(2, "Kitten", "juvenile cat", listOf("he"))
+
+    gatedViewModel.fetchTranslation(
+        TranslateViewState.OptionsFetched("cat", listOf(termA), emptyMap(), "en"),
+        termA,
+        "he",
+    )
+    advanceUntilIdle()
+    assertTrue(gatedViewModel.pageState.value is TranslateViewState.Translated)
+    assertEquals(RelatedArticlesState.Loading, gatedViewModel.relatedArticles.value)
+
+    // User moves on to another article while A's related fetch is still in flight.
+    gatedViewModel.fetchTranslation(
+        TranslateViewState.OptionsFetched("kitten", listOf(termB), emptyMap(), "en"),
+        termB,
+        "he",
+    )
+    advanceUntilIdle()
+    val translated = gatedViewModel.pageState.value as TranslateViewState.Translated
+    assertEquals("Kitten", translated.term.title)
+    assertEquals(RelatedArticlesState.Loading, gatedViewModel.relatedArticles.value)
+
+    // A's late response must not overwrite B's loading state.
+    gated.gates["Cat"]!!.complete(listOf(RelatedArticle(9, "Stale", null, null)))
+    advanceUntilIdle()
+    assertEquals(RelatedArticlesState.Loading, gatedViewModel.relatedArticles.value)
+
+    // B's response is applied normally.
+    gated.gates["Kitten"]!!.complete(listOf(RelatedArticle(3, "Purr", null, null)))
+    advanceUntilIdle()
+    val loaded = gatedViewModel.relatedArticles.value
+    assertTrue(loaded is RelatedArticlesState.Loaded)
+    assertEquals("Purr", (loaded as RelatedArticlesState.Loaded).articles[0].title)
+  }
+
+  @Test
+  fun `clearSearch discards in-flight related results`() = runTest {
+    val gated = GatedFakeTranslationRepository(mock(), mock(), FakeStringProvider())
+    val gatedViewModel =
+        TranslateViewModel(
+            gated,
+            mockRecentLanguagesRepository,
+            FakeStringProvider(),
+            mockWelcomeMessageProvider,
+            mockLanguageDetector,
+        )
+    gated.nextTranslations =
+        listOf(
+            Translation(
+                sourceWord = "Cat",
+                sourceLangCode = "en",
+                sourceArticleUrl = "url",
+                sourceShortDescription = "desc",
+                sourceSummary = "summary",
+                translatedWord = "חתול",
+                targetLangCode = "he",
+                targetArticleUrl = "url_he",
+                targetShortDescription = "desc_he",
+                targetSummary = "summary_he",
+            )
+        )
+    val termA = OptionalSourceTerm(1, "Cat", "domestic species", listOf("he"))
+
+    gatedViewModel.fetchTranslation(
+        TranslateViewState.OptionsFetched("cat", listOf(termA), emptyMap(), "en"),
+        termA,
+        "he",
+    )
+    advanceUntilIdle()
+    assertEquals(RelatedArticlesState.Loading, gatedViewModel.relatedArticles.value)
+
+    gatedViewModel.clearSearch()
+    assertEquals(RelatedArticlesState.Hidden, gatedViewModel.relatedArticles.value)
+
+    // Late response after clear must stay hidden.
+    gated.gates["Cat"]!!.complete(listOf(RelatedArticle(9, "Stale", null, null)))
+    advanceUntilIdle()
+    assertEquals(RelatedArticlesState.Hidden, gatedViewModel.relatedArticles.value)
+  }
+
+  private class GatedFakeTranslationRepository(
+      translationDao: TranslationDao,
+      wikipediaApi: LangWikipediaFactory,
+      stringProvider: StringProvider,
+  ) : FakeTranslationRepository(translationDao, wikipediaApi, stringProvider) {
+    val gates = mutableMapOf<String, CompletableDeferred<List<RelatedArticle>>>()
+
+    override suspend fun getRelatedArticles(
+        sourceLang: String,
+        sourceTitle: String,
+        sourcePageId: Long,
+        limit: Int,
+    ): List<RelatedArticle> {
+      return gates.getOrPut(sourceTitle) { CompletableDeferred() }.await()
+    }
   }
 }

--- a/app/src/test/java/com/anysoftkeyboard/janus/app/viewmodels/TranslateViewModelTest.kt
+++ b/app/src/test/java/com/anysoftkeyboard/janus/app/viewmodels/TranslateViewModelTest.kt
@@ -5,6 +5,7 @@ import com.anysoftkeyboard.janus.app.R
 import com.anysoftkeyboard.janus.app.repository.FakeTranslationRepository
 import com.anysoftkeyboard.janus.app.repository.OptionalSourceTerm
 import com.anysoftkeyboard.janus.app.repository.RecentLanguagesRepository
+import com.anysoftkeyboard.janus.app.repository.RelatedArticle
 import com.anysoftkeyboard.janus.app.util.DetectionResult
 import com.anysoftkeyboard.janus.app.util.FakeStringProvider
 import com.anysoftkeyboard.janus.app.util.LanguageDetector
@@ -745,5 +746,200 @@ class TranslateViewModelTest {
       val error = state as TranslateViewState.Error
       assertEquals(TranslateViewModel.ErrorType.SafetyViolation, error.errorType)
     }
+  }
+
+  @Test
+  fun `fetchTranslation loads related articles lazily without blocking translation`() = runTest {
+    val searchTerm =
+        OptionalSourceTerm(
+            pageid = 1,
+            title = "Cat",
+            snippet = "domestic species",
+            availableLanguages = listOf("he"),
+        )
+    val translation =
+        Translation(
+            sourceWord = "Cat",
+            sourceLangCode = "en",
+            sourceArticleUrl = "url",
+            sourceShortDescription = "desc",
+            sourceSummary = "summary",
+            translatedWord = "חתול",
+            targetLangCode = "he",
+            targetArticleUrl = "url_he",
+            targetShortDescription = "desc_he",
+            targetSummary = "summary_he",
+        )
+    fakeRepository.nextTranslations = listOf(translation)
+    fakeRepository.nextRelatedArticles =
+        listOf(RelatedArticle(2, "Kitten", "Young cat", "A kitten is a juvenile cat."))
+
+    viewModel.pageState.test {
+      assertEquals(TranslateViewState.Empty, awaitItem())
+
+      val optionsFetched =
+          TranslateViewState.OptionsFetched("test", listOf(searchTerm), emptyMap(), "en")
+      viewModel.fetchTranslation(optionsFetched, searchTerm, "he")
+      assertTrue(awaitItem() is TranslateViewState.Translating)
+      advanceUntilIdle()
+
+      // Translation is emitted even though related articles load separately
+      val translatedState = awaitItem()
+      assertTrue(translatedState is TranslateViewState.Translated)
+    }
+
+    viewModel.relatedArticles.test {
+      val loaded = awaitItem()
+      assertTrue(loaded is RelatedArticlesState.Loaded)
+      assertEquals("Kitten", (loaded as RelatedArticlesState.Loaded).articles[0].title)
+    }
+  }
+
+  @Test
+  fun `fetchTranslation hides related section when related fetch fails`() = runTest {
+    val searchTerm =
+        OptionalSourceTerm(
+            pageid = 1,
+            title = "Cat",
+            snippet = "domestic species",
+            availableLanguages = listOf("he"),
+        )
+    val translation =
+        Translation(
+            sourceWord = "Cat",
+            sourceLangCode = "en",
+            sourceArticleUrl = "url",
+            sourceShortDescription = "desc",
+            sourceSummary = "summary",
+            translatedWord = "חתול",
+            targetLangCode = "he",
+            targetArticleUrl = "url_he",
+            targetShortDescription = "desc_he",
+            targetSummary = "summary_he",
+        )
+    fakeRepository.nextTranslations = listOf(translation)
+    fakeRepository.relatedException = RuntimeException("related failed")
+
+    viewModel.pageState.test {
+      assertEquals(TranslateViewState.Empty, awaitItem())
+
+      val optionsFetched =
+          TranslateViewState.OptionsFetched("test", listOf(searchTerm), emptyMap(), "en")
+      viewModel.fetchTranslation(optionsFetched, searchTerm, "he")
+      skipItems(1) // Translating state
+      advanceUntilIdle()
+
+      // Translation still succeeds
+      val translatedState = awaitItem()
+      assertTrue(translatedState is TranslateViewState.Translated)
+    }
+
+    advanceUntilIdle()
+    assertEquals(RelatedArticlesState.Hidden, viewModel.relatedArticles.value)
+  }
+
+  @Test
+  fun `fetchTranslation hides related section when no related articles`() = runTest {
+    val searchTerm =
+        OptionalSourceTerm(
+            pageid = 1,
+            title = "Cat",
+            snippet = "domestic species",
+            availableLanguages = listOf("he"),
+        )
+    val translation =
+        Translation(
+            sourceWord = "Cat",
+            sourceLangCode = "en",
+            sourceArticleUrl = "url",
+            sourceShortDescription = "desc",
+            sourceSummary = "summary",
+            translatedWord = "חתול",
+            targetLangCode = "he",
+            targetArticleUrl = "url_he",
+            targetShortDescription = "desc_he",
+            targetSummary = "summary_he",
+        )
+    fakeRepository.nextTranslations = listOf(translation)
+    fakeRepository.nextRelatedArticles = emptyList()
+
+    val optionsFetched =
+        TranslateViewState.OptionsFetched("test", listOf(searchTerm), emptyMap(), "en")
+    viewModel.fetchTranslation(optionsFetched, searchTerm, "he")
+    advanceUntilIdle()
+
+    assertTrue(viewModel.pageState.value is TranslateViewState.Translated)
+    assertEquals(RelatedArticlesState.Hidden, viewModel.relatedArticles.value)
+  }
+
+  @Test
+  fun `fetchRelatedTranslation translates the related concept directly`() = runTest {
+    val related = RelatedArticle(5, "Kitten", "Young cat", "A kitten is a juvenile cat.")
+    val translation =
+        Translation(
+            sourceWord = "Kitten",
+            sourceLangCode = "en",
+            sourceArticleUrl = "url",
+            sourceShortDescription = "desc",
+            sourceSummary = "summary",
+            translatedWord = "חתלתול",
+            targetLangCode = "he",
+            targetArticleUrl = "url_he",
+            targetShortDescription = "desc_he",
+            targetSummary = "summary_he",
+        )
+    fakeRepository.nextTranslations = listOf(translation)
+
+    viewModel.pageState.test {
+      assertEquals(TranslateViewState.Empty, awaitItem())
+
+      viewModel.fetchRelatedTranslation(related, "en", "he")
+      assertTrue(awaitItem() is TranslateViewState.Translating)
+      advanceUntilIdle()
+
+      val translatedState = awaitItem()
+      assertTrue(translatedState is TranslateViewState.Translated)
+      val translated = translatedState as TranslateViewState.Translated
+      assertEquals("Kitten", translated.term.title)
+      assertEquals("en", translated.sourceLang)
+      assertEquals("he", translated.targetLang)
+    }
+  }
+
+  @Test
+  fun `related articles are cached per source article`() = runTest {
+    val searchTerm =
+        OptionalSourceTerm(
+            pageid = 1,
+            title = "Cat",
+            snippet = "domestic species",
+            availableLanguages = listOf("he"),
+        )
+    val translation =
+        Translation(
+            sourceWord = "Cat",
+            sourceLangCode = "en",
+            sourceArticleUrl = "url",
+            sourceShortDescription = "desc",
+            sourceSummary = "summary",
+            translatedWord = "חתול",
+            targetLangCode = "he",
+            targetArticleUrl = "url_he",
+            targetShortDescription = "desc_he",
+            targetSummary = "summary_he",
+        )
+    fakeRepository.nextTranslations = listOf(translation)
+    fakeRepository.nextRelatedArticles =
+        listOf(RelatedArticle(2, "Kitten", "Young cat", "A kitten is a juvenile cat."))
+    val optionsFetched =
+        TranslateViewState.OptionsFetched("test", listOf(searchTerm), emptyMap(), "en")
+
+    viewModel.fetchTranslation(optionsFetched, searchTerm, "he")
+    advanceUntilIdle()
+    viewModel.fetchTranslation(optionsFetched, searchTerm, "he")
+    advanceUntilIdle()
+
+    assertEquals(1, fakeRepository.getRelatedArticleCalls)
+    assertTrue(viewModel.relatedArticles.value is RelatedArticlesState.Loaded)
   }
 }

--- a/network/src/main/java/com/anysoftkeyboard/janus/network/WikipediaApi.kt
+++ b/network/src/main/java/com/anysoftkeyboard/janus/network/WikipediaApi.kt
@@ -24,4 +24,12 @@ interface WikipediaApi {
       "api.php?action=query&prop=extracts|pageprops&format=json&exintro=true&explaintext=true&exsentences=2"
   )
   suspend fun getArticleDetails(@Query("titles") titles: String): LangLinksResponse
+
+  @GET(
+      "api.php?action=query&generator=search&prop=pageprops|extracts&format=json&exintro=true&explaintext=true&exsentences=2"
+  )
+  suspend fun getRelatedArticles(
+      @Query("gsrsearch") morelikeQuery: String,
+      @Query("gsrlimit") limit: Int = 8,
+  ): LangLinksResponse
 }

--- a/network/src/test/java/com/anysoftkeyboard/janus/network/WikipediaClientTest.kt
+++ b/network/src/test/java/com/anysoftkeyboard/janus/network/WikipediaClientTest.kt
@@ -90,4 +90,58 @@ class WikipediaClientTest {
     )
     assertEquals("Monster Summer", response.query!!.search?.get(1)?.title)
   }
+
+  @Test
+  fun `test related articles response parsing`() = runBlocking {
+    val jsonResponse =
+        """
+        {
+          "batchcomplete": true,
+          "query": {
+            "pages": {
+              "895672": {
+                "pageid": 895672,
+                "ns": 0,
+                "title": "Feral cat",
+                "pageprops": {
+                  "wikibase-shortdesc": "Unowned or untamed domestic cat in the outdoors"
+                },
+                "extract": "A feral cat or stray cat is an unowned domestic cat."
+              },
+              "629216": {
+                "pageid": 629216,
+                "ns": 0,
+                "title": "Purr",
+                "pageprops": {
+                  "wikibase-shortdesc": "Fluttering vocalization"
+                },
+                "extract": "A purr or whirr is a tonal fluttering sound."
+              }
+            }
+          }
+        }
+        """
+            .trimIndent()
+
+    mockWebServer.enqueue(MockResponse().setBody(jsonResponse))
+
+    val response = wikipediaApi.getRelatedArticles("morelike:Cat", 8)
+
+    val request = mockWebServer.takeRequest()
+    assert(request.path!!.contains("generator=search"))
+    assert(request.path!!.contains("gsrsearch=morelike%3ACat"))
+
+    val pages = response.query?.pages
+    assertEquals(2, pages?.size)
+    assertEquals("Feral cat", pages?.get("895672")?.title)
+    assertEquals(
+        "Unowned or untamed domestic cat in the outdoors",
+        pages?.get("895672")?.pageProps?.wikibaseShortdesc,
+    )
+    assertEquals(
+        "A feral cat or stray cat is an unowned domestic cat.",
+        pages?.get("895672")?.extract,
+    )
+    assertEquals("Purr", pages?.get("629216")?.title)
+  }
 }


### PR DESCRIPTION
## What
Adds a **Related articles** section below the target card in the translation view (source-language, inline, up to 8 items).

- `WikipediaApi.getRelatedArticles()`: `generator=search` with `gsrsearch=morelike:{title}` + `prop=pageprops|extracts` (2-sentence intro extracts).
- `TranslationRepository.getRelatedArticles()`: filters to main-namespace, valid, non-disambiguation pages; excludes the source article; caps at limit.
- `TranslateViewModel`: new `RelatedArticlesState` (`Hidden/Loading/Loaded`) flow, fetched lazily after translation, cached per source article; tapping a related article translates it directly via `fetchRelatedTranslation()`. Empty/error hides silently.
- UI: `RelatedArticlesSection` in `TranslationView`, wired through `TranslateScreen`; strings localized (en + ar, de, es, fr, he, ru).

## Why
The legacy `rest_v1/page/related` endpoint is decommissioned (HTTP 403, phab:T376297). CirrusSearch `morelike` is WMF's canonical replacement and what Extension:RelatedArticles itself uses.

## Verification
- 10 new tests (4 repository, 5 ViewModel, 1 network MockWebServer parsing) — all green.
- `./gradlew testDebugUnitTest` + `spotlessApply` clean.
- Manually verified on device (`installGoogleDebug`): search “office” → “Office” → Hebrew translation + related list below.

Closes #41