### PR TITLE
[LLM] feat: Add Wikipedia donation link to About screen

### DIFF
--- a/app/src/main/java/com/anysoftkeyboard/janus/app/ui/AboutScreen.kt
+++ b/app/src/main/java/com/anysoftkeyboard/janus/app/ui/AboutScreen.kt
@@ -142,6 +142,12 @@ fun AboutScreen(modifier: Modifier = Modifier) {
 
         // 4. References
         ReferenceLinkRow(
+            label = stringResource(R.string.about_link_donate_wikipedia),
+            url = WIKIPEDIA_DONATE_URL,
+            context = context,
+        )
+        Spacer(modifier = Modifier.height(4.dp))
+        ReferenceLinkRow(
             label = stringResource(R.string.about_link_source_code),
             url = "https://github.com/AnySoftKeyboard/janus",
             context = context,
@@ -175,6 +181,9 @@ fun AboutScreen(modifier: Modifier = Modifier) {
   }
 }
 
+private const val WIKIPEDIA_DONATE_URL =
+    "https://donate.wikimedia.org/?utm_source=JanusGlossa&utm_medium=AndroidApp&utm_campaign=JanusGlossa"
+
 @Composable
 private fun ReferenceLinkRow(
     label: String,
@@ -187,8 +196,7 @@ private fun ReferenceLinkRow(
           modifier
               .fillMaxWidth()
               .clickable {
-                val intent =
-                    android.content.Intent(android.content.Intent.ACTION_VIEW, Uri.parse(url))
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
                 context.startActivity(intent)
               }
               .padding(vertical = 12.dp),

--- a/app/src/main/java/com/anysoftkeyboard/janus/app/ui/AboutScreen.kt
+++ b/app/src/main/java/com/anysoftkeyboard/janus/app/ui/AboutScreen.kt
@@ -1,8 +1,6 @@
 package com.anysoftkeyboard.janus.app.ui
 
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
@@ -41,6 +39,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.anysoftkeyboard.janus.app.BuildConfig
 import com.anysoftkeyboard.janus.app.R
+import com.anysoftkeyboard.janus.app.util.openUrlSafely
 import com.mikepenz.aboutlibraries.ui.compose.android.produceLibraries
 import com.mikepenz.aboutlibraries.ui.compose.m3.LibrariesContainer
 
@@ -195,10 +194,7 @@ private fun ReferenceLinkRow(
       modifier =
           modifier
               .fillMaxWidth()
-              .clickable {
-                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-                context.startActivity(intent)
-              }
+              .clickable { context.openUrlSafely(url) }
               .padding(vertical = 12.dp),
       verticalAlignment = Alignment.CenterVertically,
   ) {

--- a/app/src/main/java/com/anysoftkeyboard/janus/app/ui/components/ActionButtons.kt
+++ b/app/src/main/java/com/anysoftkeyboard/janus/app/ui/components/ActionButtons.kt
@@ -3,8 +3,6 @@ package com.anysoftkeyboard.janus.app.ui.components
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.OpenInNew
 import androidx.compose.material.icons.filled.BookmarkBorder
@@ -15,6 +13,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import com.anysoftkeyboard.janus.app.util.openUrlSafely
 
 /**
  * Icon button that opens a Wikipedia article URL in the browser.
@@ -30,12 +29,7 @@ fun WikipediaLinkButton(
     tint: Color = MaterialTheme.colorScheme.primary,
 ) {
   val context = LocalContext.current
-  IconButton(
-      onClick = {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
-        context.startActivity(intent)
-      }
-  ) {
+  IconButton(onClick = { context.openUrlSafely(url) }) {
     Icon(
         imageVector = Icons.AutoMirrored.Filled.OpenInNew,
         contentDescription = contentDescription,

--- a/app/src/main/java/com/anysoftkeyboard/janus/app/util/IntentUtils.kt
+++ b/app/src/main/java/com/anysoftkeyboard/janus/app/util/IntentUtils.kt
@@ -1,0 +1,49 @@
+package com.anysoftkeyboard.janus.app.util
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.Log
+import android.widget.Toast
+import com.anysoftkeyboard.janus.app.R
+
+private const val TAG = "IntentUtils"
+
+/**
+ * Safely opens a web URL using [Intent.ACTION_VIEW].
+ *
+ * If no browser or handler is available (e.g. headless device, kiosk mode, or restricted profile),
+ * catches [ActivityNotFoundException] or other launch exceptions, logs a warning, copies the URL to
+ * the clipboard, and displays a user-facing [Toast].
+ */
+fun Context.openUrlSafely(url: String) {
+  val intent =
+      Intent(Intent.ACTION_VIEW, Uri.parse(url)).apply {
+        if (this@openUrlSafely !is Activity) {
+          addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+      }
+  try {
+    startActivity(intent)
+  } catch (e: ActivityNotFoundException) {
+    Log.w(TAG, "No activity found to handle URL: $url", e)
+    handleOpenUrlFailure(url)
+  } catch (e: Exception) {
+    Log.e(TAG, "Failed to open URL: $url", e)
+    handleOpenUrlFailure(url)
+  }
+}
+
+private fun Context.handleOpenUrlFailure(url: String) {
+  try {
+    val clipboard = getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+    clipboard?.setPrimaryClip(ClipData.newPlainText("url", url))
+  } catch (e: Exception) {
+    Log.w(TAG, "Failed to copy URL to clipboard", e)
+  }
+  Toast.makeText(this, R.string.error_no_browser, Toast.LENGTH_LONG).show()
+}

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -85,6 +85,7 @@
     <!-- Repository errors -->
     <string name="error_page_not_found">الصفحة غير موجودة</string>
     <string name="error_langlinks_not_found">روابط الترجمة غير موجودة</string>
+    <string name="error_no_browser">لم يتم العثور على متصفح ويب. تم نسخ الرابط إلى الحافظة.</string>
 
     <!-- Content descriptions for accessibility -->
     <string name="content_description_search">بحث</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -133,6 +133,7 @@
     <string name="about_abstract">Janus Glossa هي أداة مفتوحة المصدر مصممة لترجمة المفاهيم داخل سياقها، باستخدام المعرفة الجماعية لـ ويكيبيديا.</string>
     <string name="about_methodology_title">كيف يعمل</string>
     <string name="about_methodology_text">على عكس القواميس القياسية، يقوم Janus Glossa بمحاذاة المفاهيم. فهو يبحث عن إدخال الموسوعة لمصطلحك، ثم يتبع الرابط بين اللغات إلى اللغة المستهدفة لتقديم ترجمة دقيقة ومناسبة للسياق.</string>
+    <string name="about_link_donate_wikipedia">اشكر ويكيبيديا بالتبرع</string>
     <string name="about_link_source_code">كود المصدر</string>
     <string name="about_link_issue_tracker">متتبع المشكلات</string>
     <string name="about_button_licenses">تراخيص البرمجيات مفتوحة المصدر</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -85,6 +85,7 @@
     <!-- Repository errors -->
     <string name="error_page_not_found">Seite nicht gefunden</string>
     <string name="error_langlinks_not_found">Übersetzungslinks nicht gefunden</string>
+    <string name="error_no_browser">Kein Webbrowser gefunden. Link in die Zwischenablage kopiert.</string>
 
     <!-- Content descriptions for accessibility -->
     <string name="content_description_search">Suchen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -133,6 +133,7 @@
     <string name="about_abstract">Janus Glossa ist ein Open-Source-Tool zur Übersetzung von Konzepten in ihrem Kontext, das auf das gemeinschaftliche Wissen von Wikipedia zurückgreift.</string>
     <string name="about_methodology_title">So funktioniert es</string>
     <string name="about_methodology_text">Im Gegensatz zu herkömmlichen Wörterbüchern gleicht Janus Glossa Konzepte ab. Es findet den Enzyklopädieeintrag für Ihren Begriff und folgt dann dem interlingualen Link zur Zielsprache, um eine präzise, kontextsensitive Übersetzung zu liefern.</string>
+    <string name="about_link_donate_wikipedia">Wikipedia mit einer Spende danken</string>
     <string name="about_link_source_code">Quellcode</string>
     <string name="about_link_issue_tracker">Fehlerverfolgung</string>
     <string name="about_button_licenses">Open-Source-Lizenzen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -85,6 +85,7 @@
     <!-- Repository errors -->
     <string name="error_page_not_found">Página no encontrada</string>
     <string name="error_langlinks_not_found">Enlaces de traducción no encontrados</string>
+    <string name="error_no_browser">No se encontró ningún navegador web. Enlace copiado al portapapeles.</string>
 
     <!-- Content descriptions for accessibility -->
     <string name="content_description_search">Buscar</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -133,6 +133,7 @@
     <string name="about_abstract">Janus Glossa es una herramienta de código abierto diseñada para traducir conceptos dentro de su contexto, utilizando el conocimiento colectivo de Wikipedia.</string>
     <string name="about_methodology_title">Cómo funciona</string>
     <string name="about_methodology_text">A diferencia de los diccionarios estándar, Janus Glossa alinea conceptos. Encuentra la entrada de la enciclopedia para su término y luego sigue el enlace interlingüístico al idioma de destino para proporcionar una traducción precisa y consciente del contexto.</string>
+    <string name="about_link_donate_wikipedia">Agradece a Wikipedia donando</string>
     <string name="about_link_source_code">Código fuente</string>
     <string name="about_link_issue_tracker">Seguimiento de problemas</string>
     <string name="about_button_licenses">Licencias de código abierto</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -85,6 +85,7 @@
     <!-- Repository errors -->
     <string name="error_page_not_found">Page non trouvée</string>
     <string name="error_langlinks_not_found">Liens de traduction non trouvés</string>
+    <string name="error_no_browser">Aucun navigateur Web trouvé. Lien copié dans le presse-papiers.</string>
 
     <!-- Content descriptions for accessibility -->
     <string name="content_description_search">Rechercher</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -133,6 +133,7 @@
     <string name="about_abstract">Janus Glossa est un outil open source conçu pour traduire des concepts dans leur contexte, en utilisant les connaissances collectives de Wikipédia.</string>
     <string name="about_methodology_title">Comment ça marche</string>
     <string name="about_methodology_text">Contrairement aux dictionnaires standard, Janus Glossa aligne les concepts. Il trouve l\'entrée d\'encyclopédie correspondant à votre terme, puis suit le lien interlangue vers la langue cible pour fournir une traduction précise et adaptée au contexte.</string>
+    <string name="about_link_donate_wikipedia">Remercier Wikipédia en faisant un don</string>
     <string name="about_link_source_code">Code source</string>
     <string name="about_link_issue_tracker">Suivi des problèmes</string>
     <string name="about_button_licenses">Licences open source</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -133,6 +133,7 @@
     <string name="about_abstract">Janus Glossa הוא כלי בקוד פתוח שנועד לתרגם מושגים בתוך ההקשר שלהם, תוך שימוש בידע הקהילתי של ויקיפדיה.</string>
     <string name="about_methodology_title">איך זה עובד</string>
     <string name="about_methodology_text">בניגוד למילונים רגילים, Janus Glossa מתאים מושגים. הוא מוצא את הערך באנציקלופדיה עבור המונח שלך, ואז עוקב אחר הקישור הרב-לשוני לשפת היעד כדי לספק תרגום מדויק ותלוי הקשר.</string>
+    <string name="about_link_donate_wikipedia">הודו לוויקיפדיה באמצעות תרומה</string>
     <string name="about_link_source_code">קוד מקור</string>
     <string name="about_link_issue_tracker">מעקב תקלות</string>
     <string name="about_button_licenses">רישיונות קוד פתוח</string>

--- a/app/src/main/res/values-he/strings.xml
+++ b/app/src/main/res/values-he/strings.xml
@@ -85,6 +85,7 @@
     <!-- Repository errors -->
     <string name="error_page_not_found">הדף לא נמצא</string>
     <string name="error_langlinks_not_found">קישורי תרגום לא נמצאו</string>
+    <string name="error_no_browser">לא נמצא דפדפן אינטרנט. הקישור הועתק ללוח.</string>
 
     <!-- Content descriptions for accessibility -->
     <string name="content_description_search">חיפוש</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -133,6 +133,7 @@
     <string name="about_abstract">Janus Glossa — это инструмент с открытым исходным кодом, разработанный для перевода понятий в их контексте с использованием коллективных знаний Википедии.</string>
     <string name="about_methodology_title">Как это работает</string>
     <string name="about_methodology_text">В отличие от обычных словарей, Janus Glossa сопоставляет понятия. Он находит словарную статью для вашего термина в энциклопедии, а затем переходит по межъязыковой ссылке на целевой язык, чтобы предоставить точный перевод с учетом контекста.</string>
+    <string name="about_link_donate_wikipedia">Поблагодарить Википедию пожертвованием</string>
     <string name="about_link_source_code">Исходный код</string>
     <string name="about_link_issue_tracker">Отслеживание ошибок</string>
     <string name="about_button_licenses">Лицензии открытого ПО</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -85,6 +85,7 @@
     <!-- Repository errors -->
     <string name="error_page_not_found">Страница не найдена</string>
     <string name="error_langlinks_not_found">Ссылки на переводы не найдены</string>
+    <string name="error_no_browser">Веб-браузер не найден. Ссылка скопирована в буфер обмена.</string>
 
     <!-- Content descriptions for accessibility -->
     <string name="content_description_search">Поиск</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -99,6 +99,7 @@
     <!-- Repository errors -->
     <string name="error_page_not_found">Page not found</string>
     <string name="error_langlinks_not_found">Translation links not found</string>
+    <string name="error_no_browser">No web browser found. Link copied to clipboard.</string>
 
     <!-- Content descriptions for accessibility -->
     <string name="content_description_search">Search</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,6 +148,7 @@
     <string name="about_abstract">Janus Glossa is an open-source tool designed to translate concepts within their context, utilizing the crowd-sourced knowledge of Wikipedia.</string>
     <string name="about_methodology_title">How it works</string>
     <string name="about_methodology_text">Unlike standard dictionaries, Janus Glossa aligns concepts. It finds the encyclopedia entry for your term, then follows the inter-language link to the target language to provide a precise, context-aware translation.</string>
+    <string name="about_link_donate_wikipedia">Thank Wikipedia by donating</string>
     <string name="about_link_source_code">Source Code</string>
     <string name="about_link_issue_tracker">Issue Tracker</string>
     <string name="about_button_licenses">Open Source Licenses</string>

--- a/app/src/test/java/com/anysoftkeyboard/janus/app/ui/AboutScreenTest.kt
+++ b/app/src/test/java/com/anysoftkeyboard/janus/app/ui/AboutScreenTest.kt
@@ -1,6 +1,8 @@
 package com.anysoftkeyboard.janus.app.ui
 
+import android.app.Application
 import android.content.Context
+import android.content.Intent
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
@@ -8,10 +10,14 @@ import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performScrollTo
 import androidx.test.core.app.ApplicationProvider
 import com.anysoftkeyboard.janus.app.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
 
 @RunWith(RobolectricTestRunner::class)
 class AboutScreenTest {
@@ -30,6 +36,29 @@ class AboutScreenTest {
 
     val expectedLicensesButton = context.getString(R.string.about_button_licenses)
     composeTestRule.onNodeWithText(expectedLicensesButton).performScrollTo().assertIsDisplayed()
+  }
+
+  @Test
+  fun testAboutScreen_displaysDonateLink() {
+    composeTestRule.setContent { AboutScreen() }
+
+    val expectedDonateText = context.getString(R.string.about_link_donate_wikipedia)
+    composeTestRule.onNodeWithText(expectedDonateText).performScrollTo().assertIsDisplayed()
+  }
+
+  @Test
+  fun testAboutScreen_clickDonateLink_opensBrowserWithAttribution() {
+    composeTestRule.setContent { AboutScreen() }
+
+    val donateText = context.getString(R.string.about_link_donate_wikipedia)
+    composeTestRule.onNodeWithText(donateText).performScrollTo().performClick()
+
+    val app = shadowOf(ApplicationProvider.getApplicationContext<Application>())
+    val nextIntent = app.nextStartedActivity
+    assertNotNull(nextIntent)
+    assertEquals(Intent.ACTION_VIEW, nextIntent.action)
+    assertTrue(nextIntent.dataString!!.startsWith("https://donate.wikimedia.org/"))
+    assertTrue(nextIntent.dataString!!.contains("utm_source=JanusGlossa"))
   }
 
   @Test

--- a/app/src/test/java/com/anysoftkeyboard/janus/app/ui/components/ActionButtonsTest.kt
+++ b/app/src/test/java/com/anysoftkeyboard/janus/app/ui/components/ActionButtonsTest.kt
@@ -1,17 +1,26 @@
 package com.anysoftkeyboard.janus.app.ui.components
 
+import android.app.Application
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.content.Intent
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
 import androidx.test.core.app.ApplicationProvider
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
 
 @RunWith(RobolectricTestRunner::class)
 class ActionButtonsTest {
+
+  @get:Rule val composeTestRule = createComposeRule()
 
   @Test
   fun `test clipboard copy functionality`() {
@@ -70,5 +79,19 @@ class ActionButtonsTest {
     val clipData = clipboard.primaryClip
     assertNotNull(clipData)
     assertEquals(testText, clipData?.getItemAt(0)?.text)
+  }
+
+  @Test
+  fun `test wikipedia link button click opens url safely`() {
+    val testUrl = "https://en.wikipedia.org/wiki/Cat"
+    composeTestRule.setContent { WikipediaLinkButton(url = testUrl) }
+
+    composeTestRule.onNodeWithContentDescription("Open in Wikipedia").performClick()
+
+    val app = shadowOf(ApplicationProvider.getApplicationContext<Application>())
+    val nextIntent = app.nextStartedActivity
+    assertNotNull(nextIntent)
+    assertEquals(Intent.ACTION_VIEW, nextIntent.action)
+    assertEquals(testUrl, nextIntent.dataString)
   }
 }

--- a/app/src/test/java/com/anysoftkeyboard/janus/app/util/IntentUtilsTest.kt
+++ b/app/src/test/java/com/anysoftkeyboard/janus/app/util/IntentUtilsTest.kt
@@ -1,0 +1,78 @@
+package com.anysoftkeyboard.janus.app.util
+
+import android.app.Application
+import android.content.ActivityNotFoundException
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import androidx.test.core.app.ApplicationProvider
+import com.anysoftkeyboard.janus.app.R
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.shadows.ShadowToast
+
+@RunWith(RobolectricTestRunner::class)
+class IntentUtilsTest {
+
+  private val context: Context
+    get() = ApplicationProvider.getApplicationContext()
+
+  @Test
+  fun testOpenUrlSafely_success_startsActionViewIntent() {
+    val testUrl = "https://example.com/test"
+    context.openUrlSafely(testUrl)
+
+    val app = shadowOf(ApplicationProvider.getApplicationContext<Application>())
+    val nextIntent = app.nextStartedActivity
+    assertNotNull(nextIntent)
+    assertEquals(Intent.ACTION_VIEW, nextIntent.action)
+    assertEquals(testUrl, nextIntent.dataString)
+  }
+
+  @Test
+  fun testOpenUrlSafely_activityNotFound_copiesToClipboardAndShowsToast() {
+    val failingContext =
+        object : ContextWrapper(context) {
+          override fun startActivity(intent: Intent?) {
+            throw ActivityNotFoundException("No activity found")
+          }
+        }
+
+    val testUrl = "https://example.com/fallback"
+    failingContext.openUrlSafely(testUrl)
+
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    val clip = clipboard.primaryClip
+    assertNotNull(clip)
+    assertEquals(testUrl, clip?.getItemAt(0)?.text?.toString())
+
+    val expectedToastText = context.getString(R.string.error_no_browser)
+    assertEquals(expectedToastText, ShadowToast.getTextOfLatestToast())
+  }
+
+  @Test
+  fun testOpenUrlSafely_genericException_copiesToClipboardAndShowsToast() {
+    val failingContext =
+        object : ContextWrapper(context) {
+          override fun startActivity(intent: Intent?) {
+            throw SecurityException("Locked device")
+          }
+        }
+
+    val testUrl = "https://example.com/secure"
+    failingContext.openUrlSafely(testUrl)
+
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    val clip = clipboard.primaryClip
+    assertNotNull(clip)
+    assertEquals(testUrl, clip?.getItemAt(0)?.text?.toString())
+
+    val expectedToastText = context.getString(R.string.error_no_browser)
+    assertEquals(expectedToastText, ShadowToast.getTextOfLatestToast())
+  }
+}


### PR DESCRIPTION
### What
- Added a "Thank Wikipedia by donating" reference link in `AboutScreen.kt` directly after the "How this works" methodology section.
- Integrated attribution tracking parameters on the official Wikimedia donate URL: `https://donate.wikimedia.org/?utm_source=JanusGlossa&utm_medium=AndroidApp&utm_campaign=JanusGlossa`, which automatically maps through Wikimedia's `Special:FundraiserRedirector` to `wmf_source` and `wmf_campaign` on `Special:LandingPage`.
- Introduced `Context.openUrlSafely(url: String)` in `IntentUtils.kt` to protect against `ActivityNotFoundException` on devices without browsers or with locked profiles.
- Integrated `openUrlSafely` across both `AboutScreen` (`ReferenceLinkRow`) and `ActionButtons` (`WikipediaLinkButton`). On failure, the URL is automatically copied to the clipboard and a localized Toast is displayed.
- Localized all new strings (`about_link_donate_wikipedia` and `error_no_browser`) across all supported languages (Arabic, German, Spanish, French, Hebrew, Russian, and default English).
- Added comprehensive unit tests in `AboutScreenTest`, `IntentUtilsTest`, and `ActionButtonsTest`.

### Why
- Enables users to directly support Wikimedia with referral attribution for Janus Glossa.
- Eliminates fatal crash risk on devices without installed/enabled browsers or with restricted user/kiosk profiles.